### PR TITLE
Added official forum thread to contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,7 @@
 contact_links:
+  - name: Public Server Information
+    url: https://15thmeu.net/index.php?/forums/topic/170-15th-meu-soc-official-public-server-information/
+    about: Official forum thread for the 15th MEU Realism Unit Public Server.
   - name: Public Server Help Desk
     url: https://15thmeu.net/index.php?/forums/forum/252-public-server-help-desk/
-    about: Official forum for the 15th MEU Realism Unit Public Server.
+    about: Forum for help requests.


### PR DESCRIPTION
Updated the contact links to include the primary information source about the public server.

Follows on #8.