### PR TITLE
Added 3CB MG3 magazines to custom preset

### DIFF
--- a/Missionframework/arsenal_presets/custom.sqf
+++ b/Missionframework/arsenal_presets/custom.sqf
@@ -750,6 +750,13 @@ GRLIB_arsenal_magazines = [
     "UK3CB_FNFAL_762_20Rnd",
     "UK3CB_M16_20Rnd_Mag_T",
     "UK3CB_M16_20Rnd_Mag",
+    "UK3CB_MG3_100rnd_762x51_GM",
+    "UK3CB_MG3_100rnd_762x51_RT",
+    "UK3CB_MG3_250rnd_762x51_G",
+    "UK3CB_MG3_250rnd_762x51_WT",
+    "UK3CB_MG3_50rnd_762x51_GM",
+    "UK3CB_MG3_50rnd_762x51_RT",
+    "UK3CB_MG3_50rnd_762x51_WM",
     "Vorona_HE",
     "Vorona_HEAT",
 


### PR DESCRIPTION
**Description**
Added magazines to custom arsenal preset:
- 100rnd MG3 M62 Tracer Belt (Red)
- 100rnd MG3 M80/M62 Mixed Belt (Green)
- 250rnd MG3 M62 Tracer Belt (White)
- 250rnd MG3 M80 Belt (5x Green Tracer)
- 50rnd MG3 M62 Tracer Belt (Red)
- 50rnd MG3 M80/M62 Mixed Belt (Green)
- 50rnd MG3 M80/M62 Mixed Belt (White)

**Related Issues**
Resolves #38